### PR TITLE
use bundler for dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'typhoeus'
+gem 'mechanize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,39 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
+    ethon (0.7.3)
+      ffi (>= 1.3.0)
+    ffi (1.9.8)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    mechanize (2.7.3)
+      domain_name (~> 0.5, >= 0.5.1)
+      http-cookie (~> 1.0)
+      mime-types (~> 2.0)
+      net-http-digest_auth (~> 1.1, >= 1.1.1)
+      net-http-persistent (~> 2.5, >= 2.5.2)
+      nokogiri (~> 1.4)
+      ntlm-http (~> 0.1, >= 0.1.1)
+      webrobots (>= 0.0.9, < 0.2)
+    mime-types (2.5)
+    mini_portile (0.6.2)
+    net-http-digest_auth (1.4)
+    net-http-persistent (2.9.4)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    ntlm-http (0.1.1)
+    typhoeus (0.7.1)
+      ethon (>= 0.7.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
+    webrobots (0.1.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  mechanize
+  typhoeus

--- a/README.md
+++ b/README.md
@@ -2,17 +2,11 @@
 
 Script para descargar los boletines judiciales en México.
 
-
-## Pre-Requisitos
-```bash
-gem install typhoeus
-gem install mechanize
-```
-
 ## Instalación
 
 ```bash
 git clone https://github.com/eleloya/topolegal.git
+bundle install
 ```
 
 ## Uso del script


### PR DESCRIPTION
Es mejor usar bundler para manejar las dependencias. Te evitas el tener diferentes versiones de gemas instaladas.
